### PR TITLE
feat: split Manager and Transceiver deployments

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,20 @@
+{
+    "printWidth": 120,
+    "tabWidth": 4,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": false,
+    "bracketSpacing": true,
+    "arrowParens": "always",
+    "trailingComma": "none",
+    "overrides": [
+        {
+            "files": "*.sol",
+            "options": {
+                "tabWidth": 4,
+                "singleQuote": false,
+                "explicitTypes": "always"
+            }
+        }
+    ]
+}

--- a/script/deployNttToken.s.sol
+++ b/script/deployNttToken.s.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.22;
 
-import { Script, console2 } from "forge-std/Script.sol";
-import { NttFactory } from "../src/NttFactory.sol";
-import { PeersManager } from "../src/PeersManager.sol";
+import {Script, console2} from "forge-std/Script.sol";
+import {NttFactory} from "../src/NttFactory.sol";
+import {PeersManager} from "../src/PeersManager.sol";
 
-import { INttFactory } from "../src/interfaces/INttFactory.sol";
+import {INttFactory} from "../src/interfaces/INttFactory.sol";
 
-import { IWormhole } from "wormhole-solidity-sdk/interfaces/IWormhole.sol";
-import { IManagerBase } from "native-token-transfers/interfaces/IManagerBase.sol";
+import {IWormhole} from "wormhole-solidity-sdk/interfaces/IWormhole.sol";
+import {IManagerBase} from "native-token-transfers/interfaces/IManagerBase.sol";
 
 contract NttTokenDeploy is Script {
     function run() public payable {
@@ -30,14 +30,10 @@ contract NttTokenDeploy is Script {
         });
 
         PeersManager.PeerParams[] memory peerParams = new PeersManager.PeerParams[](1);
-        peerParams[0] = PeersManager.PeerParams({ peerChainId: 2, decimals: 18, inboundLimit: type(uint64).max });
+        peerParams[0] = PeersManager.PeerParams({peerChainId: 2, decimals: 18, inboundLimit: type(uint64).max});
 
-        (address token2, , address ownerContract) = factory.deployNtt(
-            IManagerBase.Mode.BURNING,
-            tokenParams,
-            "SALT",
-            type(uint64).max
-        );
+        (address token2,, address ownerContract) =
+            factory.deployNtt(IManagerBase.Mode.BURNING, tokenParams, "SALT", type(uint64).max);
         factory.deployAndInitializeTransceiver(token2, peerParams, ownerContract);
 
         vm.stopBroadcast();

--- a/script/deployNttToken.s.sol
+++ b/script/deployNttToken.s.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.22;
 
-import {Script, console2} from "forge-std/Script.sol";
-import {NttFactory} from "../src/NttFactory.sol";
-import {PeersManager} from "../src/PeersManager.sol";
+import { Script, console2 } from "forge-std/Script.sol";
+import { NttFactory } from "../src/NttFactory.sol";
+import { PeersManager } from "../src/PeersManager.sol";
 
-import {INttFactory} from "../src/interfaces/INttFactory.sol";
+import { INttFactory } from "../src/interfaces/INttFactory.sol";
 
-import {IWormhole} from "wormhole-solidity-sdk/interfaces/IWormhole.sol";
-import {IManagerBase} from "native-token-transfers/interfaces/IManagerBase.sol";
+import { IWormhole } from "wormhole-solidity-sdk/interfaces/IWormhole.sol";
+import { IManagerBase } from "native-token-transfers/interfaces/IManagerBase.sol";
 
 contract NttTokenDeploy is Script {
     function run() public payable {
@@ -30,10 +30,15 @@ contract NttTokenDeploy is Script {
         });
 
         PeersManager.PeerParams[] memory peerParams = new PeersManager.PeerParams[](1);
-        peerParams[0] = PeersManager.PeerParams({peerChainId: 2, decimals: 18, inboundLimit: type(uint64).max});
+        peerParams[0] = PeersManager.PeerParams({ peerChainId: 2, decimals: 18, inboundLimit: type(uint64).max });
 
-        (address token2,,,) =
-            factory.deployNtt(IManagerBase.Mode.BURNING, tokenParams, "SALT", type(uint64).max, peerParams);
+        (address token2, , address ownerContract) = factory.deployNtt(
+            IManagerBase.Mode.BURNING,
+            tokenParams,
+            "SALT",
+            type(uint64).max
+        );
+        factory.deployAndInitializeTransceiver(token2, peerParams, ownerContract);
 
         vm.stopBroadcast();
 

--- a/src/NttFactory.sol
+++ b/src/NttFactory.sol
@@ -165,6 +165,9 @@ contract NttFactory is INttFactory, PeersManager {
         if (nttTransceiverBytecode.length == 0) {
             revert BytecodesNotInitialized();
         }
+        if (ownerContract == address(0)) {
+            revert InvalidOwnerContract();
+        }
         // Deploy Wormhole Transceiver.
         transceiver = deployWormholeTransceiver(nttManager);
 

--- a/src/NttFactory.sol
+++ b/src/NttFactory.sol
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.22;
 
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
-import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
-import { CREATE3 } from "solmate/utils/CREATE3.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
+import {CREATE3} from "solmate/utils/CREATE3.sol";
 
-import { Implementation } from "native-token-transfers/libraries/Implementation.sol";
-import { PausableOwnable } from "native-token-transfers/libraries/PausableOwnable.sol";
-import { IManagerBase } from "native-token-transfers/interfaces/IManagerBase.sol";
-import { INttManager } from "native-token-transfers/interfaces/INttManager.sol";
-import { IWormholeTransceiver } from "native-token-transfers/interfaces/IWormholeTransceiver.sol";
-import { INttFactory } from "./interfaces/INttFactory.sol";
-import { NttOwner } from "./NttOwner.sol";
-import { PeersManager } from "./PeersManager.sol";
-import { PeerToken } from "./tokens/PeerToken.sol";
+import {Implementation} from "native-token-transfers/libraries/Implementation.sol";
+import {PausableOwnable} from "native-token-transfers/libraries/PausableOwnable.sol";
+import {IManagerBase} from "native-token-transfers/interfaces/IManagerBase.sol";
+import {INttManager} from "native-token-transfers/interfaces/INttManager.sol";
+import {IWormholeTransceiver} from "native-token-transfers/interfaces/IWormholeTransceiver.sol";
+import {INttFactory} from "./interfaces/INttFactory.sol";
+import {NttOwner} from "./NttOwner.sol";
+import {PeersManager} from "./PeersManager.sol";
+import {PeerToken} from "./tokens/PeerToken.sol";
 
 /**
  * @title NttFactory
@@ -66,10 +66,8 @@ contract NttFactory is INttFactory, PeersManager {
         uint16 whChainId
     ) external onlyDeployer {
         if (
-            wormholeCoreBridge != address(0) ||
-            wormholeRelayer != address(0) ||
-            specialRelayer != address(0) ||
-            wormholeChainId != 0
+            wormholeCoreBridge != address(0) || wormholeRelayer != address(0) || specialRelayer != address(0)
+                || wormholeChainId != 0
         ) {
             revert WormholeConfigAlreadyInitialized();
         }
@@ -122,10 +120,8 @@ contract NttFactory is INttFactory, PeersManager {
         }
 
         if (
-            wormholeChainId == 0 ||
-            wormholeCoreBridge == address(0) ||
-            wormholeRelayer == address(0) ||
-            specialRelayer == address(0)
+            wormholeChainId == 0 || wormholeCoreBridge == address(0) || wormholeRelayer == address(0)
+                || specialRelayer == address(0)
         ) {
             revert WormholeConfigNotInitialized();
         }
@@ -146,12 +142,8 @@ contract NttFactory is INttFactory, PeersManager {
         }
 
         // deploy manager
-        DeploymentParams memory params = DeploymentParams({
-            token: token,
-            mode: mode,
-            outboundLimit: outboundLimit,
-            externalSalt: externalSalt
-        });
+        DeploymentParams memory params =
+            DeploymentParams({token: token, mode: mode, outboundLimit: outboundLimit, externalSalt: externalSalt});
         nttManager = deployNttManager(params);
 
         if (params.mode == IManagerBase.Mode.BURNING) {
@@ -166,11 +158,10 @@ contract NttFactory is INttFactory, PeersManager {
     }
 
     /// @inheritdoc INttFactory
-    function deployAndInitializeTransceiver(
-        address nttManager,
-        PeerParams[] memory peerParams,
-        address ownerContract
-    ) external returns (address transceiver) {
+    function deployAndInitializeTransceiver(address nttManager, PeerParams[] memory peerParams, address ownerContract)
+        external
+        returns (address transceiver)
+    {
         if (nttTransceiverBytecode.length == 0) {
             revert BytecodesNotInitialized();
         }
@@ -202,11 +193,10 @@ contract NttFactory is INttFactory, PeersManager {
      *      the decimal precision of the same token on other chains. Ensure proper
      *      decimal handling when integrating across chains.
      */
-    function deployToken(
-        string memory name,
-        string memory symbol,
-        string memory externalSalt
-    ) internal returns (address) {
+    function deployToken(string memory name, string memory symbol, string memory externalSalt)
+        internal
+        returns (address)
+    {
         bytes32 tokenSalt = keccak256(abi.encodePacked(version, msg.sender, name, symbol, externalSalt));
 
         // Deploy token. Initially we need to have minter and owner as this factory.
@@ -235,10 +225,8 @@ contract NttFactory is INttFactory, PeersManager {
 
     function deployAndInitializeProxy(address implementation, bytes32 salt) internal returns (address) {
         // Deploy deterministic proxy
-        bytes memory proxyCreationCode = abi.encodePacked(
-            type(ERC1967Proxy).creationCode,
-            abi.encode(implementation, "")
-        );
+        bytes memory proxyCreationCode =
+            abi.encodePacked(type(ERC1967Proxy).creationCode, abi.encode(implementation, ""));
 
         address proxy = CREATE3.deploy(salt, proxyCreationCode, 0);
 
@@ -249,9 +237,8 @@ contract NttFactory is INttFactory, PeersManager {
 
     function deployNttManager(DeploymentParams memory params) internal returns (address) {
         // We don't want to get the same bytecode if the token is the same, using externalSalt here too
-        bytes32 implementationSalt = keccak256(
-            abi.encodePacked(version, "MANAGER_IMPL", msg.sender, params.externalSalt, address(this))
-        );
+        bytes32 implementationSalt =
+            keccak256(abi.encodePacked(version, "MANAGER_IMPL", msg.sender, params.externalSalt, address(this)));
 
         bytes memory bytecode = abi.encodePacked(
             nttManagerBytecode,
@@ -267,9 +254,7 @@ contract NttFactory is INttFactory, PeersManager {
     }
 
     function deployWormholeTransceiver(address nttManager) internal returns (address) {
-        bytes32 implementationSalt = keccak256(
-            abi.encodePacked(version, "TRANSCEIVER_SALT", msg.sender, address(this))
-        );
+        bytes32 implementationSalt = keccak256(abi.encodePacked(version, "TRANSCEIVER_SALT", msg.sender, address(this)));
 
         bytes memory bytecode = abi.encodePacked(
             nttTransceiverBytecode,

--- a/src/interfaces/INttFactory.sol
+++ b/src/interfaces/INttFactory.sol
@@ -44,6 +44,7 @@ interface INttFactory is IERC165 {
     error WormholeConfigAlreadyInitialized();
     error WormholeConfigNotInitialized();
     error InvalidTokenParameters();
+    error InvalidOwnerContract();
 
     // --- Functions ---
 

--- a/src/interfaces/INttFactory.sol
+++ b/src/interfaces/INttFactory.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {IManagerBase} from "native-token-transfers/interfaces/IManagerBase.sol";
-import {PeersManager} from "./../PeersManager.sol";
-import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { IManagerBase } from "native-token-transfers/interfaces/IManagerBase.sol";
+import { PeersManager } from "./../PeersManager.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
  * @title INttFactory
@@ -29,7 +29,7 @@ interface INttFactory is IERC165 {
     event TokenDeployed(address indexed token, string name, string symbol);
     event ManagerDeployed(address indexed manager, address indexed token);
     event TransceiverDeployed(address indexed transceiver, address indexed token);
-    event NttOwnerDeployed(address indexed ownerContract, address indexed manager, address indexed transceiver);
+    event NttOwnerDeployed(address indexed ownerContract, address indexed manager);
     event ManagerBytecodeInitialized(bytes32 managerBytecode);
     event TransceiverBytecodeInitialized(bytes32 transceiverBytecode);
     event WormholeConfigInitialized(address whCoreBridge, address whRelayer, address specialRelayer, uint16 whChainId);
@@ -59,19 +59,29 @@ interface INttFactory is IERC165 {
      * @param tokenParams params to deploy or use existing params
      * @param externalSalt External salt used for deterministic deployment
      * @param outboundLimit Outbound limit for the new token
-     * @param peerParams Peer parameters for the deployment
      * @return token Address of the deployed token
      * @return nttManager Address of the deployed manager
-     * @return transceiver Address of the deployed transceiver
      * @return ownerContract Address of the contract that is owner of manager and transceiver
      */
     function deployNtt(
         IManagerBase.Mode mode,
         TokenParams memory tokenParams,
         string memory externalSalt,
-        uint256 outboundLimit,
-        PeersManager.PeerParams[] memory peerParams
-    ) external payable returns (address token, address nttManager, address transceiver, address ownerContract);
+        uint256 outboundLimit
+    ) external payable returns (address token, address nttManager, address ownerContract);
+
+    /**
+     *
+     * @notice Deploy a transceiver for an existing NTT Manager deterministically
+     * @param nttManager Address of the NTT Manager
+     * @param peerParams Peer parameters for the deployment
+     * @return transceiver Address of the deployed transceiver
+     */
+    function deployAndInitializeTransceiver(
+        address nttManager,
+        PeersManager.PeerParams[] memory peerParams,
+        address ownerContract
+    ) external returns (address transceiver);
 
     /**
      * @notice Initialize manager bytecode to be used on deploy of NTT manager

--- a/src/interfaces/INttFactory.sol
+++ b/src/interfaces/INttFactory.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import { IManagerBase } from "native-token-transfers/interfaces/IManagerBase.sol";
-import { PeersManager } from "./../PeersManager.sol";
-import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IManagerBase} from "native-token-transfers/interfaces/IManagerBase.sol";
+import {PeersManager} from "./../PeersManager.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
  * @title INttFactory

--- a/test/NttFactory.t.sol
+++ b/test/NttFactory.t.sol
@@ -3,20 +3,20 @@ pragma solidity 0.8.22;
 
 import "forge-std/Test.sol";
 
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
-import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import { NttManager } from "native-token-transfers/NttManager/NttManager.sol";
-import { WormholeTransceiver } from "native-token-transfers/Transceiver/WormholeTransceiver/WormholeTransceiver.sol";
-import { IManagerBase } from "native-token-transfers/interfaces/IManagerBase.sol";
-import { INttManager } from "native-token-transfers/interfaces/INttManager.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {NttManager} from "native-token-transfers/NttManager/NttManager.sol";
+import {WormholeTransceiver} from "native-token-transfers/Transceiver/WormholeTransceiver/WormholeTransceiver.sol";
+import {IManagerBase} from "native-token-transfers/interfaces/IManagerBase.sol";
+import {INttManager} from "native-token-transfers/interfaces/INttManager.sol";
 
-import { NttFactory } from "../src/NttFactory.sol";
-import { INttFactory } from "../src/interfaces/INttFactory.sol";
-import { PeersManager } from "../src/PeersManager.sol";
-import { NttOwner } from "../src/NttOwner.sol";
+import {NttFactory} from "../src/NttFactory.sol";
+import {INttFactory} from "../src/interfaces/INttFactory.sol";
+import {PeersManager} from "../src/PeersManager.sol";
+import {NttOwner} from "../src/NttOwner.sol";
 
-import { PeerToken } from "../src/tokens/PeerToken.sol";
+import {PeerToken} from "../src/tokens/PeerToken.sol";
 
 contract MockWormhole {
     uint16 private _chainId;
@@ -109,15 +109,11 @@ contract NttFactoryTest is Test {
     function test_DeployNtt_BurningMode() public {
         // Setup peer parameters
         PeersManager.PeerParams[] memory peerParams = new PeersManager.PeerParams[](1);
-        peerParams[0] = PeersManager.PeerParams({ peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT });
+        peerParams[0] = PeersManager.PeerParams({peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT});
 
         // Deploy NTT system
-        (address token, address nttManager, address ownerContract) = factory.deployNtt(
-            IManagerBase.Mode.BURNING,
-            tokenParamsBurning,
-            EXTERNAL_SALT,
-            OUTBOUND_LIMIT
-        );
+        (address token, address nttManager, address ownerContract) =
+            factory.deployNtt(IManagerBase.Mode.BURNING, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT);
 
         // Deploy NTT Transceiver
         address transceiver = factory.deployAndInitializeTransceiver(nttManager, peerParams, ownerContract);
@@ -150,15 +146,11 @@ contract NttFactoryTest is Test {
     function test_DeployNtt_LockingMode() public {
         // Setup peer parameters
         PeersManager.PeerParams[] memory peerParams = new PeersManager.PeerParams[](1);
-        peerParams[0] = PeersManager.PeerParams({ peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT });
+        peerParams[0] = PeersManager.PeerParams({peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT});
 
         // Deploy NTT system
-        (address token, address nttManager, address ownerContract) = factory.deployNtt(
-            IManagerBase.Mode.LOCKING,
-            tokenParamsLocking,
-            EXTERNAL_SALT,
-            OUTBOUND_LIMIT
-        );
+        (address token, address nttManager, address ownerContract) =
+            factory.deployNtt(IManagerBase.Mode.LOCKING, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT);
 
         // Deploy NTT Transceiver
         address transceiver = factory.deployAndInitializeTransceiver(nttManager, peerParams, ownerContract);
@@ -212,26 +204,17 @@ contract NttFactoryTest is Test {
         IManagerBase.Mode mode = IManagerBase.Mode.BURNING;
 
         PeersManager.PeerParams[] memory peerParams = new PeersManager.PeerParams[](1);
-        peerParams[0] = PeersManager.PeerParams({ peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT });
+        peerParams[0] = PeersManager.PeerParams({peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT});
 
         // Deploy twice with same parameters
-        (address token1, address manager1, ) = factory.deployNtt(
-            mode,
-            tokenParamsBurning,
-            EXTERNAL_SALT,
-            OUTBOUND_LIMIT
-        );
+        (address token1, address manager1,) = factory.deployNtt(mode, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT);
 
         vm.expectRevert(); // Should revert on second deployment with same parameters
         factory.deployNtt(mode, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT);
 
         // should not fail with a different external salt
-        (address token2, address manager2, ) = factory.deployNtt(
-            mode,
-            tokenParamsBurning,
-            "DIFFERENT_SALT",
-            OUTBOUND_LIMIT
-        );
+        (address token2, address manager2,) =
+            factory.deployNtt(mode, tokenParamsBurning, "DIFFERENT_SALT", OUTBOUND_LIMIT);
 
         // Verify first deployment was successful
         assertTrue(token1 != address(0));
@@ -246,26 +229,17 @@ contract NttFactoryTest is Test {
         IManagerBase.Mode mode = IManagerBase.Mode.LOCKING;
 
         PeersManager.PeerParams[] memory peerParams = new PeersManager.PeerParams[](1);
-        peerParams[0] = PeersManager.PeerParams({ peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT });
+        peerParams[0] = PeersManager.PeerParams({peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT});
 
         // Deploy twice with same parameters
-        (address token1, address manager1, ) = factory.deployNtt(
-            mode,
-            tokenParamsLocking,
-            EXTERNAL_SALT,
-            OUTBOUND_LIMIT
-        );
+        (address token1, address manager1,) = factory.deployNtt(mode, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT);
 
         vm.expectRevert(); // Should revert on second deployment with same parameters
         factory.deployNtt(mode, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT);
 
         // should not fail with a different external salt
-        (address token2, address manager2, ) = factory.deployNtt(
-            mode,
-            tokenParamsLocking,
-            "DIFFERENT_SALT",
-            OUTBOUND_LIMIT
-        );
+        (address token2, address manager2,) =
+            factory.deployNtt(mode, tokenParamsLocking, "DIFFERENT_SALT", OUTBOUND_LIMIT);
 
         // Verify first deployment was successful
         assertTrue(token1 != address(0));
@@ -280,15 +254,11 @@ contract NttFactoryTest is Test {
         IManagerBase.Mode mode = IManagerBase.Mode.BURNING;
 
         PeersManager.PeerParams[] memory peerParams = new PeersManager.PeerParams[](1);
-        peerParams[0] = PeersManager.PeerParams({ peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT });
+        peerParams[0] = PeersManager.PeerParams({peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT});
 
         // Deploy twice with same parameters
-        (address token1, address manager1, address ownerContract) = factory.deployNtt(
-            mode,
-            tokenParamsLocking,
-            EXTERNAL_SALT,
-            OUTBOUND_LIMIT
-        );
+        (address token1, address manager1, address ownerContract) =
+            factory.deployNtt(mode, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT);
         // Deploy NTT Transceiver
         address transceiver1 = factory.deployAndInitializeTransceiver(manager1, peerParams, ownerContract);
 
@@ -301,15 +271,11 @@ contract NttFactoryTest is Test {
         IManagerBase.Mode mode = IManagerBase.Mode.LOCKING;
 
         PeersManager.PeerParams[] memory peerParams = new PeersManager.PeerParams[](1);
-        peerParams[0] = PeersManager.PeerParams({ peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT });
+        peerParams[0] = PeersManager.PeerParams({peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT});
 
         // Deploy twice with same parameters
-        (address token1, address manager1, address ownerContract) = factory.deployNtt(
-            mode,
-            tokenParamsLocking,
-            EXTERNAL_SALT,
-            OUTBOUND_LIMIT
-        );
+        (address token1, address manager1, address ownerContract) =
+            factory.deployNtt(mode, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT);
         // Deploy NTT Transceiver
         address transceiver1 = factory.deployAndInitializeTransceiver(manager1, peerParams, ownerContract);
 
@@ -322,17 +288,13 @@ contract NttFactoryTest is Test {
         IManagerBase.Mode mode = IManagerBase.Mode.BURNING;
 
         PeersManager.PeerParams[] memory peerParams1 = new PeersManager.PeerParams[](1);
-        peerParams1[0] = PeersManager.PeerParams({ peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT });
+        peerParams1[0] = PeersManager.PeerParams({peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT});
 
         PeersManager.PeerParams[] memory peerParams2 = new PeersManager.PeerParams[](1);
-        peerParams2[0] = PeersManager.PeerParams({ peerChainId: 3, decimals: 8, inboundLimit: OUTBOUND_LIMIT });
+        peerParams2[0] = PeersManager.PeerParams({peerChainId: 3, decimals: 8, inboundLimit: OUTBOUND_LIMIT});
 
-        (, address manager, address ownerContract) = factory.deployNtt(
-            mode,
-            tokenParamsBurning,
-            EXTERNAL_SALT,
-            OUTBOUND_LIMIT
-        );
+        (, address manager, address ownerContract) =
+            factory.deployNtt(mode, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT);
         // Deploy NTT Transceiver
         address transceiver = factory.deployAndInitializeTransceiver(manager, peerParams1, ownerContract);
 
@@ -340,10 +302,8 @@ contract NttFactoryTest is Test {
         NttOwner(ownerContract).setPeers(manager, transceiver, peerParams2);
         vm.stopPrank();
 
-        INttManager.NttManagerPeer memory peer = INttManager.NttManagerPeer({
-            tokenDecimals: 8,
-            peerAddress: bytes32(uint256(uint160((address(manager)))))
-        });
+        INttManager.NttManagerPeer memory peer =
+            INttManager.NttManagerPeer({tokenDecimals: 8, peerAddress: bytes32(uint256(uint160((address(manager)))))});
         assertEq(INttManager(manager).getPeer(3).tokenDecimals, peer.tokenDecimals);
         assertEq(INttManager(manager).getPeer(3).peerAddress, peer.peerAddress);
 
@@ -356,14 +316,10 @@ contract NttFactoryTest is Test {
         IManagerBase.Mode mode = IManagerBase.Mode.BURNING;
 
         PeersManager.PeerParams[] memory peerParams1 = new PeersManager.PeerParams[](1);
-        peerParams1[0] = PeersManager.PeerParams({ peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT });
+        peerParams1[0] = PeersManager.PeerParams({peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT});
 
-        (, address manager, address ownerContract) = factory.deployNtt(
-            mode,
-            tokenParamsBurning,
-            EXTERNAL_SALT,
-            OUTBOUND_LIMIT
-        );
+        (, address manager, address ownerContract) =
+            factory.deployNtt(mode, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT);
         // Deploy NTT Transceiver
         factory.deployAndInitializeTransceiver(manager, peerParams1, ownerContract);
 


### PR DESCRIPTION
This PR adds changes to the NTT deployment process by splitting the deployment of the NTT transceiver into a separate function and updates the configuration and testing files. 
The most important changes include modifications to the `deployNtt` function, the addition of the `deployAndInitializeTransceiver` function, and updates to the test cases.
Permission delegations to the admin contract have been move to the `deployAndInitializeTransceiver` function, which wraps up the set up process, to avoid being locked out after the manager is deployed.
