### PR TITLE
Create token + avax support + fix CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ OPTIMISM_ETHERSCAN_KEY=<your_optimism_etherscan_key>
 
 
 NTT_FACTORY=
+
+TOKEN_NAME=<your_token_name>
+TOKEN_SYMBOL=<your_token_symbol>

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,45 +1,45 @@
 name: CI
 
 on:
-  push:
-  pull_request:
-  workflow_dispatch:
+    push:
+    pull_request:
+    workflow_dispatch:
 
 env:
-  FOUNDRY_PROFILE: ci
+    FOUNDRY_PROFILE: ci
 
 jobs:
-  check:
-    strategy:
-      fail-fast: true
+    check:
+        strategy:
+            fail-fast: true
 
-    name: Foundry project
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+        name: Foundry project
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  submodules: recursive
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
+            - name: Install Foundry
+              uses: foundry-rs/foundry-toolchain@v1
+              with:
+                  version: nightly
 
-      - name: Show Forge version
-        run: |
-          forge --version
+            - name: Show Forge version
+              run: |
+                  forge --version
 
-      - name: Run Forge fmt
-        run: |
-          forge fmt --check
-        id: fmt
+            - name: Run Forge fmt
+              run: |
+                  forge fmt --check
+              id: fmt
 
-      - name: Run Forge build
-        run: |
-          forge build --via-ir --sizes
-        id: build
+            - name: Run Forge build
+              run: |
+                  forge build --via-ir --sizes --optimize
+              id: build
 
-      - name: Run Forge tests
-        run: |
-          forge test -vvv
-        id: test
+            - name: Run Forge tests
+              run: |
+                  forge test -vvv
+              id: test

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/
 broadcast/
 
 *.txt
+.vscode/

--- a/deploy.sh
+++ b/deploy.sh
@@ -27,6 +27,7 @@ if [ -n "$VERSION" ]; then
                 -vv \
                 --via-ir \
                 --verify \
+                --optimize \
                 --rpc-url $network 
         fi
     done < addresses.csv

--- a/script/deployNttToken.s.sol
+++ b/script/deployNttToken.s.sol
@@ -31,9 +31,10 @@ contract NttTokenDeploy is Script {
 
         PeersManager.PeerParams[] memory peerParams = new PeersManager.PeerParams[](1);
         peerParams[0] = PeersManager.PeerParams({peerChainId: 2, decimals: 18, inboundLimit: type(uint64).max});
-
-        (address token2,,,) =
-            factory.deployNtt(IManagerBase.Mode.BURNING, tokenParams, "SALT", type(uint64).max, peerParams, true);
+        uint256 wormholeMessageFee = IWormhole(factory.wormholeCoreBridge()).messageFee();
+        (address token2,,,) = factory.deployNtt{value: wormholeMessageFee * 2}(
+            IManagerBase.Mode.BURNING, tokenParams, "SALT", type(uint64).max, peerParams, true
+        );
 
         vm.stopBroadcast();
 

--- a/script/deployNttToken.s.sol
+++ b/script/deployNttToken.s.sol
@@ -33,7 +33,7 @@ contract NttTokenDeploy is Script {
         peerParams[0] = PeersManager.PeerParams({peerChainId: 2, decimals: 18, inboundLimit: type(uint64).max});
 
         (address token2,,,) =
-            factory.deployNtt(IManagerBase.Mode.BURNING, tokenParams, "SALT", type(uint64).max, peerParams);
+            factory.deployNtt(IManagerBase.Mode.BURNING, tokenParams, "SALT", type(uint64).max, peerParams, true);
 
         vm.stopBroadcast();
 

--- a/script/deployNttToken.s.sol
+++ b/script/deployNttToken.s.sol
@@ -15,8 +15,8 @@ contract NttTokenDeploy is Script {
         uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
         address nttFactory = vm.envAddress("NTT_FACTORY");
 
-        string memory tokenName = vm.envString("BURNING_TOKEN_NAME");
-        string memory tokenSymbol = vm.envString("BURNING_TOKEN_SYMBOL");
+        string memory tokenName = vm.envString("TOKEN_NAME");
+        string memory tokenSymbol = vm.envString("TOKEN_SYMBOL");
 
         NttFactory factory = NttFactory(nttFactory);
 

--- a/src/NttFactory.sol
+++ b/src/NttFactory.sol
@@ -117,7 +117,8 @@ contract NttFactory is INttFactory, PeersManager {
         TokenParams memory tokenParams,
         string memory externalSalt,
         uint256 outboundLimit,
-        PeerParams[] memory peerParams
+        PeerParams[] memory peerParams,
+        bool createToken
     ) external payable returns (address token, address nttManager, address transceiver, address nttOwnerAddress) {
         if (bytes(tokenParams.name).length == 0 || bytes(tokenParams.symbol).length == 0) {
             revert InvalidTokenParameters();
@@ -137,9 +138,8 @@ contract NttFactory is INttFactory, PeersManager {
 
         NttOwner ownerContract = new NttOwner(owner);
 
-        token = (mode == IManagerBase.Mode.BURNING)
-            ? deployToken(tokenParams.name, tokenParams.symbol, externalSalt)
-            : tokenParams.existingAddress;
+        token =
+            createToken ? deployToken(tokenParams.name, tokenParams.symbol, externalSalt) : tokenParams.existingAddress;
 
         if (token == address(0)) {
             revert InvalidTokenParameters();

--- a/src/NttFactory.sol
+++ b/src/NttFactory.sol
@@ -134,7 +134,10 @@ contract NttFactory is INttFactory, PeersManager {
             revert WormholeConfigNotInitialized();
         }
 
-        if (nttManagerBytecode1 == address(0) || nttManagerBytecode2 == address(0) || nttTransceiverBytecode == address(0)) {
+        if (
+            nttManagerBytecode1 == address(0) || nttManagerBytecode2 == address(0)
+                || nttTransceiverBytecode == address(0)
+        ) {
             revert BytecodesNotInitialized();
         }
         address owner = msg.sender;

--- a/src/interfaces/INttFactory.sol
+++ b/src/interfaces/INttFactory.sol
@@ -70,7 +70,8 @@ interface INttFactory is IERC165 {
         TokenParams memory tokenParams,
         string memory externalSalt,
         uint256 outboundLimit,
-        PeersManager.PeerParams[] memory peerParams
+        PeersManager.PeerParams[] memory peerParams,
+        bool createToken
     ) external payable returns (address token, address nttManager, address transceiver, address ownerContract);
 
     /**

--- a/test/NttFactory.t.sol
+++ b/test/NttFactory.t.sol
@@ -119,7 +119,7 @@ contract NttFactoryTest is Test {
         // Deploy NTT system
         (address token, address nttManager, address transceiver, address ownerContract) = factory.deployNtt{
             value: wormholeMessageFee * 2
-        }(IManagerBase.Mode.BURNING, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams);
+        }(IManagerBase.Mode.BURNING, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams, true);
 
         // Verify token deployment
         PeerToken deployedToken = PeerToken(token);
@@ -154,7 +154,7 @@ contract NttFactoryTest is Test {
         // Deploy NTT system
         (address token, address nttManager, address transceiver, address ownerContract) = factory.deployNtt{
             value: wormholeMessageFee * 2
-        }(IManagerBase.Mode.LOCKING, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams);
+        }(IManagerBase.Mode.LOCKING, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams, false);
 
         // Verify token is the existing one
         assertEq(token, address(existing_token));
@@ -191,7 +191,7 @@ contract NttFactoryTest is Test {
         // Test empty token name
         vm.expectRevert(INttFactory.InvalidTokenParameters.selector);
         factory.deployNtt{value: wormholeMessageFee * 2}(
-            IManagerBase.Mode.BURNING, tokenParamsEmptyName, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams
+            IManagerBase.Mode.BURNING, tokenParamsEmptyName, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams, true
         );
 
         // Test empty token symbol
@@ -204,7 +204,7 @@ contract NttFactoryTest is Test {
 
         vm.expectRevert(INttFactory.InvalidTokenParameters.selector);
         factory.deployNtt{value: wormholeMessageFee * 2}(
-            IManagerBase.Mode.BURNING, tokenParamsEmptySymbol, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams
+            IManagerBase.Mode.BURNING, tokenParamsEmptySymbol, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams, true
         );
     }
 
@@ -216,17 +216,17 @@ contract NttFactoryTest is Test {
 
         // Deploy twice with same parameters
         (address token1, address manager1, address transceiver1,) = factory.deployNtt{value: wormholeMessageFee * 2}(
-            mode, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams
+            mode, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams, true
         );
 
         vm.expectRevert(); // Should revert on second deployment with same parameters
         factory.deployNtt{value: wormholeMessageFee * 2}(
-            mode, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams
+            mode, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams, true
         );
 
         // should not fail with a different external salt
         (address token2, address manager2, address transceiver2,) = factory.deployNtt{value: wormholeMessageFee * 2}(
-            mode, tokenParamsBurning, "DIFFERENT_SALT", OUTBOUND_LIMIT, peerParams
+            mode, tokenParamsBurning, "DIFFERENT_SALT", OUTBOUND_LIMIT, peerParams, true
         );
 
         // Verify first deployment was successful
@@ -248,17 +248,17 @@ contract NttFactoryTest is Test {
 
         // Deploy twice with same parameters
         (address token1, address manager1, address transceiver1,) = factory.deployNtt{value: wormholeMessageFee * 2}(
-            mode, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams
+            mode, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams, false
         );
 
         vm.expectRevert(); // Should revert on second deployment with same parameters
         factory.deployNtt{value: wormholeMessageFee * 2}(
-            mode, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams
+            mode, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams, false
         );
 
         // should not fail with a different external salt
         (address token2, address manager2, address transceiver2,) = factory.deployNtt{value: wormholeMessageFee * 2}(
-            mode, tokenParamsLocking, "DIFFERENT_SALT", OUTBOUND_LIMIT, peerParams
+            mode, tokenParamsLocking, "DIFFERENT_SALT", OUTBOUND_LIMIT, peerParams, false
         );
 
         // Verify first deployment was successful
@@ -281,7 +281,7 @@ contract NttFactoryTest is Test {
         // Deploy twice with same parameters
         (address token1, address manager1, address transceiver1, address ownerContract) = factory.deployNtt{
             value: wormholeMessageFee * 2
-        }(mode, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams);
+        }(mode, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams, true);
 
         assertEq(Ownable(token1).owner(), OWNER);
         assertEq(Ownable(manager1).owner(), ownerContract);
@@ -297,7 +297,7 @@ contract NttFactoryTest is Test {
         // Deploy twice with same parameters
         (address token1, address manager1, address transceiver1, address ownerContract) = factory.deployNtt{
             value: wormholeMessageFee * 2
-        }(mode, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams);
+        }(mode, tokenParamsLocking, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams, false);
 
         assertEq(Ownable(token1).owner(), EXISTING_TOKEN_OWNER);
         assertEq(Ownable(manager1).owner(), ownerContract);
@@ -314,7 +314,7 @@ contract NttFactoryTest is Test {
         peerParams2[0] = PeersManager.PeerParams({peerChainId: 3, decimals: 8, inboundLimit: OUTBOUND_LIMIT});
         (, address manager, address transceiver, address ownerContract) = factory.deployNtt{
             value: wormholeMessageFee * 2
-        }(mode, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams1);
+        }(mode, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams1, true);
 
         vm.startPrank(address(OWNER));
         NttOwner(ownerContract).setPeers{value: wormholeMessageFee}(manager, transceiver, peerParams2);
@@ -338,7 +338,7 @@ contract NttFactoryTest is Test {
         peerParams1[0] = PeersManager.PeerParams({peerChainId: 2, decimals: 18, inboundLimit: OUTBOUND_LIMIT});
 
         (, address manager,, address ownerContract) = factory.deployNtt{value: wormholeMessageFee * 2}(
-            mode, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams1
+            mode, tokenParamsBurning, EXTERNAL_SALT, OUTBOUND_LIMIT, peerParams1, true
         );
 
         vm.startPrank(address(OWNER));


### PR DESCRIPTION
1. use `--optimize` in CI and `deploy.sh`
2. optionally create a token as part of `deployNtt`
3. Use `SSTORE2` to store NTTManager and WH Transceiver bytecode (cheaper gas write/reads)
4. Split NTTManager bytecode in 2, because init + runtime code is over 24kb, so it cannot be stored using `SSTORE2` in a single call. It could be split without SSTORE2 but saving 24+kb in storage seems like an overkill. This is because AVAX has a lower block gas limit and reading that much data from storage is too expensive. Using this approach for all chains instead of creating an AVAX-specific solution
5. Use `messageFee` in the deploy token script